### PR TITLE
Various Fixes

### DIFF
--- a/lib/rack/session.rb
+++ b/lib/rack/session.rb
@@ -1,6 +1,7 @@
-
 module Rack
-  RACK_SESSION                        = 'rack.session'
-  RACK_SESSION_OPTIONS                = 'rack.session.options'
-  RACK_SESSION_UNPACKED_COOKIE_DATA   = 'rack.session.unpacked_cookie_data'
+  module Session
+    autoload :Cookie, "rack/session/cookie"
+    autoload :Pool, "rack/session/pool"
+    autoload :Memcache, "rack/session/memcache"
+  end
 end

--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -11,6 +11,8 @@ require 'rack/constants'
 require 'rack/request'
 require 'rack/response'
 
+require_relative '../constants'
+
 module Rack
 
   module Session

--- a/lib/rack/session/constants.rb
+++ b/lib/rack/session/constants.rb
@@ -1,6 +1,7 @@
-
 module Rack
   module Session
+    RACK_SESSION                        = 'rack.session'
+    RACK_SESSION_OPTIONS                = 'rack.session.options'
     RACK_SESSION_UNPACKED_COOKIE_DATA   = 'rack.session.unpacked_cookie_data'
   end
 end

--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -152,7 +152,8 @@ module Rack
       attr_reader :coder, :encryptors
 
       def initialize(app, options = {})
-        secrets = [*options[:secrets]]
+        # support both :secrets and :secret for backwards compatibility
+        secrets = [*(options[:secrets] || options[:secret])]
 
         encryptor_opts = {
           purpose: options[:key], serialize_json: options[:serialize_json]
@@ -164,11 +165,12 @@ module Rack
           Rack::Session::Encryptor.new secret, encryptor_opts
         end
 
-        # If a legacy HMAC secret is present, initialize those features
-        if options.has_key?(:legacy_hmac_secret)
+        # If a legacy HMAC secret is present, initialize those features.
+        # Fallback to :secret for backwards compatibility.
+        if options.has_key?(:legacy_hmac_secret) || options.has_key?(:secret)
           @legacy_hmac = options.fetch(:legacy_hmac, 'SHA1')
 
-          @legacy_hmac_secret = options[:legacy_hmac_secret]
+          @legacy_hmac_secret = options[:legacy_hmac_secret] || options[:secret]
           @legacy_hmac_coder  = options.fetch(:legacy_hmac_coder, Base64::Marshal.new)
         else
           @legacy_hmac = false

--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -11,6 +11,7 @@ require 'rack/utils'
 
 require_relative 'abstract/id'
 require_relative 'encryptor'
+require_relative 'constants'
 
 module Rack
 

--- a/rack-session.gemspec
+++ b/rack-session.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A session implementation for Rack."
   spec.license = "MIT"
 
-  spec.files = Dir.glob('{lib}/**/*', File::FNM_DOTMATCH, base: __dir__)
+  spec.files = Dir.glob('lib/**/*.rb')
 
   spec.require_path = 'lib'
 


### PR DESCRIPTION
Fix autoloading.

Avoid defining constants that conflict with Rack.

Make Rack::Session::Cookie backwards compatible with :secret option.