### PR TITLE
Allow for Rack 3 beta gem to be loaded

### DIFF
--- a/rack-session.gemspec
+++ b/rack-session.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4.0'
 
-  spec.add_dependency "rack", "~> 3.0"
+  spec.add_dependency "rack", ">= 3.0.0.beta1"
 
   spec.add_development_dependency 'minitest', "~> 5.0"
   spec.add_development_dependency 'minitest-sprint'


### PR DESCRIPTION
Without this, rack-session won't load the rack 3 beta.