### PR TITLE
Require rack/session in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ In your `config.ru`:
 ```ruby
 # config.ru
 
+require 'rack/session'
 use Rack::Session::Cookie,
   :domain => 'mywebsite.com',
   :path => '/',


### PR DESCRIPTION
As rack-session has been removed from rack, rack itself will not
autoload Rack::Session.

Related to discussion in #6.