### PR TITLE
Commit session if changed instead of loaded

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -342,20 +342,23 @@ module Rack
           value && !value.empty?
         end
 
-        # Session should be committed if it was loaded, any of specific options like :renew, :drop
+        # Session should be committed if it was changed, any of specific options like :renew, :drop
         # or :expire_after was given and the security permissions match. Skips if skip is given.
 
         def commit_session?(req, session, options)
-          if options[:skip]
-            false
-          else
-            has_session = loaded_session?(session) || forced_session_update?(session, options)
-            has_session && security_matches?(req, options)
-          end
+          return false if options[:skip]
+          return false unless security_matches?(req, options)
+          return true if forced_session_update?(session, options)
+
+          changed_session?(session)
         end
 
         def loaded_session?(session)
           !session.is_a?(session_class) || session.loaded?
+        end
+
+        def changed_session?(session)
+          !session.is_a?(session_class) || session.changed?
         end
 
         def forced_session_update?(session, options)

--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -354,13 +354,13 @@ module Rack
         end
 
         def loaded_session?(session)
-          return true if !session.is_a?(session_class)
+          return true if session.is_a?(session_class)
 
           session.loaded?
         end
 
         def changed_session?(session)
-          return true if !session.is_a?(session_class)
+          return true if session.is_a?(session_class)
 
           if session.respond_to?(:changed?)
             session.changed?

--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -354,11 +354,19 @@ module Rack
         end
 
         def loaded_session?(session)
-          !session.is_a?(session_class) || session.loaded?
+          return true if !session.is_a?(session_class)
+
+          session.loaded?
         end
 
         def changed_session?(session)
-          !session.is_a?(session_class) || session.changed?
+          return true if !session.is_a?(session_class)
+
+          if session.respond_to?(:changed?)
+            session.changed?
+          else
+            loaded_session?(session)
+          end
         end
 
         def forced_session_update?(session, options)


### PR DESCRIPTION
When concurrent requests are made from the browser to the server, all of them load the session to get the information about the current user, and one of the requests stores some data in the session. Due to racing, there is a chance that a response that reads from the session will overwrite the session value set by a response that writes to the session.

These changes are not going to solve the issue of the overwritten session but are going to make them less frequent. Also will reduce actions done in runtime like cookie encrypting and signing.

The issue was reported:
- https://stackoverflow.com/questions/42044076/why-is-rails-constantly-sending-back-a-set-cookie-header

Related to:
- https://github.com/rails/rails/pull/49129