### PR TITLE
Add Ruby 3.3 to CI matrix

### DIFF
--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -24,6 +24,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
     
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
         
         experimental: [false]
         


### PR DESCRIPTION
This PR adds Ruby 3.3 to CI matrix. related https://github.com/rack/rack/pull/2142