### PR TITLE
Declare base64 as a dependency

### DIFF
--- a/rack-session.gemspec
+++ b/rack-session.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
+  spec.add_dependency "base64"
   spec.add_dependency "rack", ">= 3.0.0"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
base64 will be removed from the default gems in Ruby 3.4, see https://github.com/rack/rack/pull/2110

Since this uses base64 in more than just one place I created a module containing the needed methods instead. That way usage is clear and easy to follow.

Because this basically copies the whole of https://github.com/ruby/base64/blob/master/lib/base64.rb (sans docs) I have included their license in the file. I wouldn't have bothered for just the pack/unpack wrappers but the url encode/decode methods are a bit more involved.

The newrelic gem is one where I have taken the similar approach to this if you are interested: https://github.com/newrelic/newrelic-ruby-agent/pull/2378. In most other gems I was just able to do the same thing as in rack itself.