### PR TITLE
Specify the `base64` dependency

### DIFF
--- a/rack-session.gemspec
+++ b/rack-session.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
+  spec.add_dependency "base64", ">= 0.1.0"
   spec.add_dependency "rack", ">= 3.0.0"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Addresses this warning (on Ruby 3.3):

> /app/lib/rack/session/cookie.rb:11: warning: base64 was loaded from
> the standard library, but is not part of the default gems since Ruby
> 3.4.0. Add base64 to your Gemfile or gemspec.

Close https://github.com/rack/rack-session/pull/30