### PR TITLE
Add cookie option "partitioned" to DEFAULT_OPTIONS and documentation

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -215,7 +215,7 @@ module Rack
       # All parameters are optional.
       # * :key determines the name of the cookie, by default it is
       #   'rack.session'
-      # * :path, :domain, :expire_after, :secure, :httponly, and :same_site set
+      # * :path, :domain, :expire_after, :secure, :httponly, :partitioned and :same_site set
       #   the related cookie options as by Rack::Response#set_cookie
       # * :skip will not a set a cookie in the response nor update the session state
       # * :defer will not set a cookie in the response but still update the session
@@ -244,6 +244,7 @@ module Rack
           expire_after: nil,
           secure: false,
           httponly: true,
+          partitioned: false,
           defer: false,
           renew: false,
           sidbits: 128,


### PR DESCRIPTION
Add clarity for Issue #42 by documenting that partitioned can be passed when setting up Persisted sessions.
Sets a default of false to partitioned in DEFAULT_OPTIONS.
Will only be active once Rack 3.1 is deployed which adds the partitioned attribute to cookies in Response.set_cookie