### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/rack-session.gemspec
+++ b/rack-session.gemspec
@@ -16,6 +16,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5"
 
+  spec.metadata = {
+    "rubygems_mfa_required" => "true"
+  }
+
   spec.add_dependency "base64", ">= 0.1.0"
   spec.add_dependency "rack", ">= 3.0.0"
 


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/