### PR TITLE
Don't set encryptor `purpose` when using default key

### DIFF
--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -161,7 +161,7 @@ module Rack
         secrets = [*(options[:secrets] || options[:secret])]
 
         encryptor_opts = {
-          purpose: options[:key], serialize_json: options[:serialize_json]
+          purpose: options[:key] != RACK_SESSION ? options[:key] : nil, serialize_json: options[:serialize_json]
         }
 
         # For each secret, create an Encryptor. We have iterate this Array at

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -366,14 +366,18 @@ describe Rack::Session::Cookie do
   end
 
   it 'rejects session cookie with different purpose' do
-    app = [incrementor, { secrets: @secrets }]
-    other_app = [incrementor, { secrets: @secrets, key: 'other' }]
+    app = [incrementor, { secrets: @secret }] # key defaults to 'rack.session'
+    other_app = [incrementor, { secrets: @secret, key: 'other' }]
+    explicit_default_app = [incrementor, { secrets: @secret, key: 'rack.session' }]
 
     response = response_for(app: app)
     response.body.must_equal ({"counter"=>1}.to_s)
 
     response = response_for(app: app, cookie: response)
     response.body.must_equal ({"counter"=>2}.to_s)
+
+    response = response_for(app: explicit_default_app, cookie: response)
+    response.body.must_equal ({"counter"=>3}.to_s)
 
     response = response_for(app: other_app, cookie: response)
     response.body.must_equal ({"counter"=>1}.to_s)


### PR DESCRIPTION
Hello, this is my first contribution! 

This PR closes #35; `rake test` passes all tests.

I decided to preserve the `purpose: nil` behavior when the default key is passed to avoid breaking cookies using the existing default behavior (e.g. without an explicit `key: "rack.session"`).

There was a typo in the `"rejects session cookie with different purpose"` test. `@secrets` (with an -s) is undefined, but switching to `@secret` (no -s, defined on [line 77](https://github.com/rack/rack-session/blob/7a4e2dd5625b141e68bb35ecbca2ecae87155c76/test/spec_session_cookie.rb#L77)) allowed the reported issue to fail in the new test prior to the fix.

